### PR TITLE
Modify make files to build on Ubuntu trusty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ install-tools: all
 include fw/Makefile
 include lib/Makefile
 include usb-common/Makefile
+
+dev_libs :=  -L$(dir $(ci20_lib)) -lci20 -lusb-1.0
+
 include usb-boot/Makefile
 include usb-nand/Makefile
 include usb-test/Makefile

--- a/fw/debug.h
+++ b/fw/debug.h
@@ -18,7 +18,7 @@ static inline void debug_init(void)
 	if (!config_enabled(DEBUG))
 		return;
 
-	uart_init(4, 115200);
+	uart_init(0, 115200);
 }
 
 static inline void debug(const char *str)

--- a/fw/main.c
+++ b/fw/main.c
@@ -9,6 +9,7 @@
 
 #include "debug.h"
 #include "io.h"
+#include "regs.h"
 #include "usb.h"
 
 void main(void)
@@ -19,4 +20,18 @@ void main(void)
 	while (1) {
 		usb_poll();
 	}
+}
+
+
+void ci20_fw_reset(void)
+{
+	debug("restart requested\n");
+	*CI20_REG_TCER = 0;
+	*CI20_REG_TCSR = 1;
+	*CI20_REG_TCNT = 0;
+	*CI20_REG_TDR = 10;
+	debug("waiting for reset\n\n ");
+	*CI20_REG_TCER = 1;
+	while(1)
+		;
 }

--- a/fw/main.c
+++ b/fw/main.c
@@ -9,7 +9,6 @@
 
 #include "debug.h"
 #include "io.h"
-#include "regs.h"
 #include "usb.h"
 
 void main(void)
@@ -20,18 +19,4 @@ void main(void)
 	while (1) {
 		usb_poll();
 	}
-}
-
-
-void ci20_fw_reset(void)
-{
-	debug("restart requested\n");
-	*CI20_REG_TCER = 0;
-	*CI20_REG_TCSR = 1;
-	*CI20_REG_TCNT = 0;
-	*CI20_REG_TDR = 10;
-	debug("waiting for reset\n\n ");
-	*CI20_REG_TCER = 1;
-	while(1)
-		;
 }

--- a/fw/protocol.h
+++ b/fw/protocol.h
@@ -30,7 +30,6 @@ enum {
 	FW_REQ_JUMP,
 	FW_REQ_BULK_LENGTH,
 	FW_REQ_UART_INIT,
-	FW_REQ_RESTART,
 };
 
 struct ci20_fw_mem_set {

--- a/fw/protocol.h
+++ b/fw/protocol.h
@@ -30,6 +30,7 @@ enum {
 	FW_REQ_JUMP,
 	FW_REQ_BULK_LENGTH,
 	FW_REQ_UART_INIT,
+	FW_REQ_RESTART,
 };
 
 struct ci20_fw_mem_set {

--- a/fw/regs.h
+++ b/fw/regs.h
@@ -45,9 +45,4 @@
 #define s8 $30
 #define ra $31
 
-#define CI20_REG_TDR  ((volatile uint32_t *)0xb0002000)
-#define CI20_REG_TCER ((volatile uint32_t *)0xb0002004)
-#define CI20_REG_TCNT ((volatile uint32_t *)0xb0002008)
-#define CI20_REG_TCSR ((volatile uint32_t *)0xb000200C)
-
 #endif /* __FW_REGS_H__ */

--- a/fw/regs.h
+++ b/fw/regs.h
@@ -45,4 +45,9 @@
 #define s8 $30
 #define ra $31
 
+#define CI20_REG_TDR  ((volatile uint32_t *)0xb0002000)
+#define CI20_REG_TCER ((volatile uint32_t *)0xb0002004)
+#define CI20_REG_TCNT ((volatile uint32_t *)0xb0002008)
+#define CI20_REG_TCSR ((volatile uint32_t *)0xb000200C)
+
 #endif /* __FW_REGS_H__ */

--- a/fw/uart.c
+++ b/fw/uart.c
@@ -40,6 +40,7 @@ UART_GEN_ACCESSORS(4, mcr)
 UART_GEN_ACCESSORS(5, lsr)
 UART_GEN_ACCESSORS(6, msr)
 UART_GEN_ACCESSORS(7, spr)
+UART_GEN_ACCESSORS(0x11, tcr)
 
 #undef UART_GEN_ACCESSORS
 
@@ -93,7 +94,8 @@ void uart_putc(char c)
 {
 	if (c == '\n')
 		uart_putc('\r');
-	while (!(read_lsr() & LSR_THRE));
+	while (read_tcr() & ((1 << 7) - 1))
+		;
 	write_thr(c);
 }
 

--- a/fw/uart.c
+++ b/fw/uart.c
@@ -40,7 +40,6 @@ UART_GEN_ACCESSORS(4, mcr)
 UART_GEN_ACCESSORS(5, lsr)
 UART_GEN_ACCESSORS(6, msr)
 UART_GEN_ACCESSORS(7, spr)
-UART_GEN_ACCESSORS(0x11, tcr)
 
 #undef UART_GEN_ACCESSORS
 
@@ -92,10 +91,7 @@ void uart_init(unsigned uart, unsigned baud)
 
 void uart_putc(char c)
 {
-	if (c == '\n')
-		uart_putc('\r');
-	while (read_tcr() & ((1 << 7) - 1))
-		;
+	while (!(read_lsr() & LSR_THRE));
 	write_thr(c);
 }
 

--- a/fw/uart.c
+++ b/fw/uart.c
@@ -91,6 +91,8 @@ void uart_init(unsigned uart, unsigned baud)
 
 void uart_putc(char c)
 {
+	if (c == '\n')
+		uart_putc('\r');
 	while (!(read_lsr() & LSR_THRE));
 	write_thr(c);
 }

--- a/fw/usb.c
+++ b/fw/usb.c
@@ -300,6 +300,10 @@ static void handle_vendor_request(void)
 
 		uart_init(setup_packet.wValue, baud);
 		break;
+
+	case FW_REQ_RESTART:
+		ci20_fw_reset();
+		break;
 	}
 }
 

--- a/fw/usb.c
+++ b/fw/usb.c
@@ -112,14 +112,14 @@ static void handle_descriptor_request(void)
 		default:
 			debug("WARN: unhandled string descriptor 0x");
 			debug_hex(idx, 0);
-			debug("\n");
+			debug("\r\n");
 		}
 		break;
 
 	default:
 		debug("WARN: unhandled descriptor type 0x");
 		debug_hex(type, 0);
-		debug("\n");
+		debug("\r\n");
 	}
 }
 
@@ -133,7 +133,7 @@ static void handle_standard_request(void)
 	default:
 		debug("WARN: unhandled standard request 0x");
 		debug_hex(setup_packet.bRequest, 2);
-		debug("\n");
+		debug("\r\n");
 	}
 }
 
@@ -152,7 +152,7 @@ static void handle_vendor_request(void)
 		in_data.data = cpu_info;
 		in_data.size = sizeof(cpu_info);
 
-		debug("GET_CPU_INFO\n");
+		debug("GET_CPU_INFO\r\n");
 		break;
 
 	case FW_REQ_MEM_READ:
@@ -163,7 +163,7 @@ static void handle_vendor_request(void)
 		debug_hex((uint32_t)in_data.data, 8);
 		debug(" length=0x");
 		debug_hex(in_data.size, 0);
-		debug("\n");
+		debug("\r\n");
 		break;
 
 	case FW_REQ_MEM_WRITE:
@@ -174,7 +174,7 @@ static void handle_vendor_request(void)
 		debug_hex((uint32_t)out_data.data, 8);
 		debug(" length=0x");
 		debug_hex(out_data.size, 0);
-		debug("\n");
+		debug("\r\n");
 		break;
 
 	case FW_REQ_MEM_SET:
@@ -184,7 +184,7 @@ static void handle_vendor_request(void)
 
 		debug("MEM_SET addr=0x");
 		debug_hex((uint32_t)cmd_data.mem_set.base, 8);
-		debug("\n");
+		debug("\r\n");
 		break;
 
 	case FW_REQ_CACHE_INIT:
@@ -192,19 +192,19 @@ static void handle_vendor_request(void)
 
 		switch (setup_packet.wValue) {
 		case CACHE_D:
-			debug(" DCACHE\n");
+			debug(" DCACHE\r\n");
 			init_dcache();
 			break;
 
 		case CACHE_I:
-			debug(" ICACHE\n");
+			debug(" ICACHE\r\n");
 			init_icache();
 			break;
 
 		default:
 			debug(" unknown=0x");
 			debug_hex(setup_packet.wValue, 0);
-			debug("\n");
+			debug("\r\n");
 			break;
 		}
 		break;
@@ -218,17 +218,17 @@ static void handle_vendor_request(void)
 
 		switch (setup_packet.wValue) {
 		case CACHE_D:
-			debug(" DCACHE\n");
+			debug(" DCACHE\r\n");
 			break;
 
 		case CACHE_I:
-			debug(" ICACHE\n");
+			debug(" ICACHE\r\n");
 			break;
 
 		default:
 			debug(" unknown=0x");
 			debug_hex(setup_packet.wValue, 0);
-			debug("\n");
+			debug("\r\n");
 			break;
 		}
 		break;
@@ -238,7 +238,7 @@ static void handle_vendor_request(void)
 		debug_hex(setup_packet.wValue, 0);
 		debug(" sel=0x");
 		debug_hex(setup_packet.wIndex, 0);
-		debug("\n");
+		debug("\r\n");
 
 		cmd_data.mfc0.value = dynamic_mfc0(setup_packet.wValue,
 						   setup_packet.wIndex);
@@ -252,7 +252,7 @@ static void handle_vendor_request(void)
 		debug_hex(setup_packet.wValue, 0);
 		debug(" sel=0x");
 		debug_hex(setup_packet.wIndex, 0);
-		debug("\n");
+		debug("\r\n");
 
 		cmd_data.mtc0.reg = setup_packet.wValue;
 		cmd_data.mtc0.sel = setup_packet.wIndex;
@@ -264,7 +264,7 @@ static void handle_vendor_request(void)
 	case FW_REQ_JUMP:
 		debug("JUMP addr=0x");
 		debug_hex(u32val, 8);
-		debug("\n");
+		debug("\r\n");
 
 		cmd_data.jump.addr = u32val;
 		break;
@@ -272,7 +272,7 @@ static void handle_vendor_request(void)
 	case FW_REQ_BULK_LENGTH:
 		debug("BULK_LENGTH len=0x");
 		debug_hex(u32val, 8);
-		debug("\n");
+		debug("\r\n");
 
 		switch (prev_cmd) {
 		case FW_REQ_MEM_READ:
@@ -284,7 +284,7 @@ static void handle_vendor_request(void)
 			break;
 
 		default:
-			debug("   INVALID!\n");
+			debug("   INVALID!\r\n");
 			break;
 		}
 		break;
@@ -296,13 +296,9 @@ static void handle_vendor_request(void)
 		debug_hex(setup_packet.wValue, 0);
 		debug(" baud=0x");
 		debug_hex(baud, 0);
-		debug("\n");
+		debug("\r\n");
 
 		uart_init(setup_packet.wValue, baud);
-		break;
-
-	case FW_REQ_RESTART:
-		ci20_fw_reset();
 		break;
 	}
 }
@@ -357,13 +353,13 @@ static void handle_start_fram_interrupt(void)
 
 static void handle_usb_reset_interrupt(void)
 {
-	debug("usb_reset\n");
+	debug("usb_reset\r\n");
 	set_gint_sts(GINTSTS_USB_RESET);
 }
 
 static void handle_enum_done_interrupt(void)
 {
-	debug("enum_done\n");
+	debug("enum_done\r\n");
 	set_gint_sts(GINTSTS_ENUM_DONE);
 }
 
@@ -389,7 +385,7 @@ static void read_out_data(unsigned ep, unsigned sz)
 		if (out_data.size >= 4) {
 			debug("<< 0x");
 			debug_hex(val, 8);
-			debug("\n");
+			debug("\r\n");
 
 			*((volatile uint32_t *)out_data.data) = val;
 			out_data.data += 4;
@@ -397,7 +393,7 @@ static void read_out_data(unsigned ep, unsigned sz)
 		} else while (out_data.size > 0) {
 			debug("<< 0x");
 			debug_hex(val & 0xff, 2);
-			debug("\n");
+			debug("\r\n");
 
 			*((volatile uint8_t *)out_data.data) = val;
 			val >>= 8;
@@ -492,7 +488,7 @@ static void handle_iep_interrupt(void)
 
 				debug(">> 0x");
 				debug_hex(val, 8);
-				debug("\n");
+				debug("\r\n");
 				write_ep_fifo(ep, val);
 
 				in_data.data += 4;
@@ -519,7 +515,7 @@ static void handle_iep_interrupt(void)
 
 			debug(">> 0x");
 			debug_hex(short_data, (xfered % 4) * 2);
-			debug("\n");
+			debug("\r\n");
 			write_ep_fifo(ep, short_data);
 		}
 

--- a/fw/usb.c
+++ b/fw/usb.c
@@ -302,7 +302,7 @@ static void handle_vendor_request(void)
 		break;
 
 	case FW_REQ_RESTART:
-		debug("restart requested\n");
+		ci20_fw_reset();
 		break;
 	}
 }

--- a/fw/usb.c
+++ b/fw/usb.c
@@ -112,14 +112,14 @@ static void handle_descriptor_request(void)
 		default:
 			debug("WARN: unhandled string descriptor 0x");
 			debug_hex(idx, 0);
-			debug("\r\n");
+			debug("\n");
 		}
 		break;
 
 	default:
 		debug("WARN: unhandled descriptor type 0x");
 		debug_hex(type, 0);
-		debug("\r\n");
+		debug("\n");
 	}
 }
 
@@ -133,7 +133,7 @@ static void handle_standard_request(void)
 	default:
 		debug("WARN: unhandled standard request 0x");
 		debug_hex(setup_packet.bRequest, 2);
-		debug("\r\n");
+		debug("\n");
 	}
 }
 
@@ -152,7 +152,7 @@ static void handle_vendor_request(void)
 		in_data.data = cpu_info;
 		in_data.size = sizeof(cpu_info);
 
-		debug("GET_CPU_INFO\r\n");
+		debug("GET_CPU_INFO\n");
 		break;
 
 	case FW_REQ_MEM_READ:
@@ -163,7 +163,7 @@ static void handle_vendor_request(void)
 		debug_hex((uint32_t)in_data.data, 8);
 		debug(" length=0x");
 		debug_hex(in_data.size, 0);
-		debug("\r\n");
+		debug("\n");
 		break;
 
 	case FW_REQ_MEM_WRITE:
@@ -174,7 +174,7 @@ static void handle_vendor_request(void)
 		debug_hex((uint32_t)out_data.data, 8);
 		debug(" length=0x");
 		debug_hex(out_data.size, 0);
-		debug("\r\n");
+		debug("\n");
 		break;
 
 	case FW_REQ_MEM_SET:
@@ -184,7 +184,7 @@ static void handle_vendor_request(void)
 
 		debug("MEM_SET addr=0x");
 		debug_hex((uint32_t)cmd_data.mem_set.base, 8);
-		debug("\r\n");
+		debug("\n");
 		break;
 
 	case FW_REQ_CACHE_INIT:
@@ -192,19 +192,19 @@ static void handle_vendor_request(void)
 
 		switch (setup_packet.wValue) {
 		case CACHE_D:
-			debug(" DCACHE\r\n");
+			debug(" DCACHE\n");
 			init_dcache();
 			break;
 
 		case CACHE_I:
-			debug(" ICACHE\r\n");
+			debug(" ICACHE\n");
 			init_icache();
 			break;
 
 		default:
 			debug(" unknown=0x");
 			debug_hex(setup_packet.wValue, 0);
-			debug("\r\n");
+			debug("\n");
 			break;
 		}
 		break;
@@ -218,17 +218,17 @@ static void handle_vendor_request(void)
 
 		switch (setup_packet.wValue) {
 		case CACHE_D:
-			debug(" DCACHE\r\n");
+			debug(" DCACHE\n");
 			break;
 
 		case CACHE_I:
-			debug(" ICACHE\r\n");
+			debug(" ICACHE\n");
 			break;
 
 		default:
 			debug(" unknown=0x");
 			debug_hex(setup_packet.wValue, 0);
-			debug("\r\n");
+			debug("\n");
 			break;
 		}
 		break;
@@ -238,7 +238,7 @@ static void handle_vendor_request(void)
 		debug_hex(setup_packet.wValue, 0);
 		debug(" sel=0x");
 		debug_hex(setup_packet.wIndex, 0);
-		debug("\r\n");
+		debug("\n");
 
 		cmd_data.mfc0.value = dynamic_mfc0(setup_packet.wValue,
 						   setup_packet.wIndex);
@@ -252,7 +252,7 @@ static void handle_vendor_request(void)
 		debug_hex(setup_packet.wValue, 0);
 		debug(" sel=0x");
 		debug_hex(setup_packet.wIndex, 0);
-		debug("\r\n");
+		debug("\n");
 
 		cmd_data.mtc0.reg = setup_packet.wValue;
 		cmd_data.mtc0.sel = setup_packet.wIndex;
@@ -264,7 +264,7 @@ static void handle_vendor_request(void)
 	case FW_REQ_JUMP:
 		debug("JUMP addr=0x");
 		debug_hex(u32val, 8);
-		debug("\r\n");
+		debug("\n");
 
 		cmd_data.jump.addr = u32val;
 		break;
@@ -272,7 +272,7 @@ static void handle_vendor_request(void)
 	case FW_REQ_BULK_LENGTH:
 		debug("BULK_LENGTH len=0x");
 		debug_hex(u32val, 8);
-		debug("\r\n");
+		debug("\n");
 
 		switch (prev_cmd) {
 		case FW_REQ_MEM_READ:
@@ -284,7 +284,7 @@ static void handle_vendor_request(void)
 			break;
 
 		default:
-			debug("   INVALID!\r\n");
+			debug("   INVALID!\n");
 			break;
 		}
 		break;
@@ -296,7 +296,7 @@ static void handle_vendor_request(void)
 		debug_hex(setup_packet.wValue, 0);
 		debug(" baud=0x");
 		debug_hex(baud, 0);
-		debug("\r\n");
+		debug("\n");
 
 		uart_init(setup_packet.wValue, baud);
 		break;
@@ -353,13 +353,13 @@ static void handle_start_fram_interrupt(void)
 
 static void handle_usb_reset_interrupt(void)
 {
-	debug("usb_reset\r\n");
+	debug("usb_reset\n");
 	set_gint_sts(GINTSTS_USB_RESET);
 }
 
 static void handle_enum_done_interrupt(void)
 {
-	debug("enum_done\r\n");
+	debug("enum_done\n");
 	set_gint_sts(GINTSTS_ENUM_DONE);
 }
 
@@ -385,7 +385,7 @@ static void read_out_data(unsigned ep, unsigned sz)
 		if (out_data.size >= 4) {
 			debug("<< 0x");
 			debug_hex(val, 8);
-			debug("\r\n");
+			debug("\n");
 
 			*((volatile uint32_t *)out_data.data) = val;
 			out_data.data += 4;
@@ -393,7 +393,7 @@ static void read_out_data(unsigned ep, unsigned sz)
 		} else while (out_data.size > 0) {
 			debug("<< 0x");
 			debug_hex(val & 0xff, 2);
-			debug("\r\n");
+			debug("\n");
 
 			*((volatile uint8_t *)out_data.data) = val;
 			val >>= 8;
@@ -488,7 +488,7 @@ static void handle_iep_interrupt(void)
 
 				debug(">> 0x");
 				debug_hex(val, 8);
-				debug("\r\n");
+				debug("\n");
 				write_ep_fifo(ep, val);
 
 				in_data.data += 4;
@@ -515,7 +515,7 @@ static void handle_iep_interrupt(void)
 
 			debug(">> 0x");
 			debug_hex(short_data, (xfered % 4) * 2);
-			debug("\r\n");
+			debug("\n");
 			write_ep_fifo(ep, short_data);
 		}
 

--- a/fw/usb.c
+++ b/fw/usb.c
@@ -300,6 +300,10 @@ static void handle_vendor_request(void)
 
 		uart_init(setup_packet.wValue, baud);
 		break;
+
+	case FW_REQ_RESTART:
+		debug("restart requested\n");
+		break;
 	}
 }
 

--- a/fw/util.h
+++ b/fw/util.h
@@ -30,4 +30,6 @@
 
 #define clz __builtin_clz
 
+extern void ci20_fw_reset(void);
+
 #endif /* __FW_UTIL_H__ */

--- a/fw/util.h
+++ b/fw/util.h
@@ -30,6 +30,4 @@
 
 #define clz __builtin_clz
 
-extern void ci20_fw_reset(void);
-
 #endif /* __FW_UTIL_H__ */

--- a/lib/usb.c
+++ b/lib/usb.c
@@ -169,8 +169,6 @@ dev_err:
 
 void ci20_usb_close(struct ci20_usb_dev *dev)
 {
-	ci20_usb_restart(dev);
-
 	if (dev->next == dev) {
 		dev->usb->devices = NULL;
 	} else {
@@ -196,19 +194,6 @@ int ci20_usb_readmem(struct ci20_usb_dev *dev, void *buf, size_t sz, uint32_t ad
 		return err;
 	if (err != sz)
 		return -EIO;
-	return 0;
-}
-
-int ci20_usb_restart(struct ci20_usb_dev *dev)
-{
-	int err;
-
-	err = libusb_control_transfer(
-		dev->hnd,
-		LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE,
-		FW_REQ_RESTART, 0, 0, (unsigned char *)&err, 0, dev->timeout);
-	if (err < 0)
-		return err;
 	return 0;
 }
 

--- a/lib/usb.c
+++ b/lib/usb.c
@@ -169,6 +169,8 @@ dev_err:
 
 void ci20_usb_close(struct ci20_usb_dev *dev)
 {
+	ci20_usb_restart(dev);
+
 	if (dev->next == dev) {
 		dev->usb->devices = NULL;
 	} else {
@@ -194,6 +196,19 @@ int ci20_usb_readmem(struct ci20_usb_dev *dev, void *buf, size_t sz, uint32_t ad
 		return err;
 	if (err != sz)
 		return -EIO;
+	return 0;
+}
+
+int ci20_usb_restart(struct ci20_usb_dev *dev)
+{
+	int err;
+
+	err = libusb_control_transfer(
+		dev->hnd,
+		LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE,
+		FW_REQ_RESTART, 0, 0, (unsigned char *)&err, 0, dev->timeout);
+	if (err < 0)
+		return err;
 	return 0;
 }
 

--- a/lib/usb.h
+++ b/lib/usb.h
@@ -50,6 +50,5 @@ extern int ci20_usb_mtc0(struct ci20_usb_dev *dev, unsigned reg, unsigned sel, u
 extern int ci20_usb_jump(struct ci20_usb_dev *dev, uint32_t addr);
 
 extern int ci20_usb_uart_init(struct ci20_usb_dev *dev, unsigned uart, unsigned baud);
-extern int ci20_usb_restart(struct ci20_usb_dev *dev);
 
 #endif /* __usb_usb_h__ */

--- a/lib/usb.h
+++ b/lib/usb.h
@@ -50,5 +50,6 @@ extern int ci20_usb_mtc0(struct ci20_usb_dev *dev, unsigned reg, unsigned sel, u
 extern int ci20_usb_jump(struct ci20_usb_dev *dev, uint32_t addr);
 
 extern int ci20_usb_uart_init(struct ci20_usb_dev *dev, unsigned uart, unsigned baud);
+extern int ci20_usb_restart(struct ci20_usb_dev *dev);
 
 #endif /* __usb_usb_h__ */

--- a/usb-boot/Makefile
+++ b/usb-boot/Makefile
@@ -16,16 +16,13 @@ source := $(addprefix usb-boot/,$(source_files))
 objs := $(addprefix $(local_out)/,$(patsubst %.c,%.o,$(source_files)))
 -include $(objs:.o=.o.d)
 
-libs := \
-	-L$(dir $(ci20_lib)) -lci20
-
 all: $(local_out)/ci20-usb-boot
 $(local_out)/ci20-usb-boot: objs := $(objs)
 $(local_out)/ci20-usb-boot: libs := $(libs)
 $(local_out)/ci20-usb-boot: $(objs) $(ci20_lib) $(common_lib)
 	@mkdir -p $(dir $@)
 	@echo "CCLD    $@"
-	$(SILENT)$(CC) $(LDFLAGS) $(libs) -o $@ $(objs) $(common_lib)
+	$(SILENT)$(CC) $(LDFLAGS) -o $@ $(objs) $(dev_libs) $(common_lib)
 
 $(objs): $$(patsubst $(local_out)/%.o,usb-boot/%.c,$$@) Makefile usb-boot/Makefile
 	@mkdir -p $(dir $@)

--- a/usb-nand/Makefile
+++ b/usb-nand/Makefile
@@ -16,16 +16,13 @@ source := $(addprefix usb-nand/,$(source_files))
 objs := $(addprefix $(local_out)/,$(patsubst %.c,%.o,$(source_files)))
 -include $(objs:.o=.o.d)
 
-libs := \
-	-L$(dir $(ci20_lib)) -lci20
-
 all: $(local_out)/ci20-usb-nand
 $(local_out)/ci20-usb-nand: objs := $(objs)
 $(local_out)/ci20-usb-nand: libs := $(libs)
 $(local_out)/ci20-usb-nand: $(objs) $(ci20_lib) $(common_lib)
 	@mkdir -p $(dir $@)
 	@echo "CCLD    $@"
-	$(SILENT)$(CC) $(LDFLAGS) $(libs) -o $@ $(objs) $(common_lib)
+	$(SILENT)$(CC) $(LDFLAGS) -o $@ $(objs) $(dev_libs) $(common_lib)
 
 $(objs): $$(patsubst $(local_out)/%.o,usb-nand/%.c,$$@) Makefile usb-nand/Makefile
 	@mkdir -p $(dir $@)

--- a/usb-test/Makefile
+++ b/usb-test/Makefile
@@ -16,16 +16,13 @@ source := $(addprefix usb-test/,$(source_files))
 objs := $(addprefix $(local_out)/,$(patsubst %.c,%.o,$(source_files)))
 -include $(objs:.o=.o.d)
 
-libs := \
-	-L$(dir $(ci20_lib)) -lci20
-
 all: $(local_out)/ci20-usb-test
 $(local_out)/ci20-usb-test: objs := $(objs)
 $(local_out)/ci20-usb-test: libs := $(libs)
 $(local_out)/ci20-usb-test: $(objs) $(ci20_lib) $(common_lib)
 	@mkdir -p $(dir $@)
 	@echo "CCLD    $@"
-	$(SILENT)$(CC) $(LDFLAGS) $(libs) -o $@ $(objs) $(common_lib)
+	$(SILENT)$(CC) $(LDFLAGS) -o $@ $(objs) $(dev_libs) $(common_lib)
 
 $(objs): $$(patsubst $(local_out)/%.o,usb-test/%.c,$$@) Makefile usb-test/Makefile
 	@mkdir -p $(dir $@)

--- a/usb-test/main.c
+++ b/usb-test/main.c
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
 	       otp.mac[0], otp.mac[1], otp.mac[2],
 	       otp.mac[3], otp.mac[4], otp.mac[5]);
 
-	for (i = 0; i < 10; i++) {
+	for (i = 0; i < 2; i++) {
 		ci20_pin_config(dev, 5, 15, PIN_GPIO_OUT_LOW + (i % 2));
 		sleep(1);
 	}

--- a/usb-test/main.c
+++ b/usb-test/main.c
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
 	       otp.mac[0], otp.mac[1], otp.mac[2],
 	       otp.mac[3], otp.mac[4], otp.mac[5]);
 
-	for (i = 0; i < 2; i++) {
+	for (i = 0; i < 10; i++) {
 		ci20_pin_config(dev, 5, 15, PIN_GPIO_OUT_LOW + (i % 2));
 		sleep(1);
 	}


### PR DESCRIPTION
The 2014.05-27 Mentor Graphics MIPS toolchain by default does not look
back at the libraries once they have been processed, this causes
linker to throw unresolved name errors even when the names are present
in the earlier processed libraries.

Another issue is that libusbdev-1.0 library required by the utilities
is not included unless explicitly mentioned in the command line.

With these suggested changes running 'make' in the top level directory
on Ubuntu 14.04 does not fail any more.

Signed-off-by: Vadim Bendebury vbendeb@chromium.org
